### PR TITLE
Memfault coredump fixes

### DIFF
--- a/components/panics/src/memfault_coredump.c
+++ b/components/panics/src/memfault_coredump.c
@@ -419,6 +419,7 @@ static bool prv_write_coredump_sections(const sMemfaultCoredumpSaveInfo *save_in
     }
   }
 
+  info.size = HPY_MEMFAULT_PART_SIZE;
   // erase storage provided we aren't just computing the size
   if (!compute_size_only && !memfault_platform_coredump_storage_erase(0, info.size)) {
     return false;

--- a/components/panics/src/memfault_coredump.c
+++ b/components/panics/src/memfault_coredump.c
@@ -18,6 +18,9 @@
 #include "memfault/core/math.h"
 #include "memfault/core/platform/device_info.h"
 #include "memfault/panics/platform/coredump.h"
+#include "memfault/ports/watchdog.h"
+
+#include "flash_partitions.h"
 
 #define MEMFAULT_COREDUMP_MAGIC 0x45524f43
 
@@ -421,6 +424,14 @@ static bool prv_write_coredump_sections(const sMemfaultCoredumpSaveInfo *save_in
     return false;
   }
 
+  // Erase takes a while.
+  //
+  // Unconditionally feed the watchdog. If it's not in use this is benign. If
+  // it is in use this will give us another 2.6s to complete the coredump save.
+  if (memfault_software_watchdog_feed() != 0) {
+    return false;
+  }
+
   sMfltCoredumpWriteCtx write_ctx = {
     // We will write the header last as a way to mark validity
     // so advance the offset past it to start
@@ -458,10 +469,16 @@ static bool prv_write_coredump_sections(const sMemfaultCoredumpSaveInfo *save_in
   size_t num_sdk_regions = 0;
   const sMfltCoredumpRegion *sdk_regions = memfault_coredump_get_sdk_regions(&num_sdk_regions);
 
-  const bool write_completed =
+  bool write_completed =
       prv_write_regions(&write_ctx, arch_regions, num_arch_regions) &&
-      prv_write_regions(&write_ctx, sdk_regions, num_sdk_regions) &&
-      prv_write_regions(&write_ctx, regions, num_regions);
+      prv_write_regions(&write_ctx, sdk_regions, num_sdk_regions);
+  // Unconditionally feed the watchdog. If it's not in use this is benign. If
+  // it is in use this will give us another 2.6s to complete the coredump save.
+  if (memfault_software_watchdog_feed() != 0) {
+    return false;
+  }
+
+  write_completed &= prv_write_regions(&write_ctx, regions, num_regions);
 
   if (!write_completed && write_ctx.write_error) {
     return false;

--- a/components/panics/src/memfault_coredump_storage_debug.c
+++ b/components/panics/src/memfault_coredump_storage_debug.c
@@ -31,6 +31,7 @@
 #include "memfault/core/debug_log.h"
 #include "memfault/core/math.h"
 #include "memfault/panics/platform/coredump.h"
+#include "flash_partitions.h"
 
 typedef enum {
   kMemfaultCoredumpStorageTestOp_Prepare = 0,
@@ -87,6 +88,7 @@ static bool prv_verify_erased(uint8_t byte) {
 bool memfault_coredump_storage_debug_test_begin(void) {
   sMfltCoredumpStorageInfo info = { 0 };
   memfault_platform_coredump_storage_get_info(&info);
+  info.size = HPY_MEMFAULT_PART_SIZE;
   if (info.size == 0) {
     prv_record_failure(kMemfaultCoredumpStorageTestOp_GetInfo,
                        kMemfaultCoredumpStorageResult_PlatformApiFail,

--- a/ports/dialog/da1468x/qspi_coredump_storage.c
+++ b/ports/dialog/da1468x/qspi_coredump_storage.c
@@ -40,6 +40,8 @@
 #include "hw_cpm.h"
 #include "hw_qspi.h"
 #include "partition_def.h"
+#include "flash_partitions.h"
+#include <ad_nvms_direct.h>
 
 #include <string.h>
 
@@ -80,6 +82,18 @@ typedef struct {
 
 static sQspiCoredumpPartitionInfo s_qspi_coredump_partition_info;
 
+static struct partition_t static_mem_part = {.next = NULL,
+                        .driver=NULL,
+                        .driver_data=NULL,
+                        .data = {.flags= 0,
+                                .magic=234,
+                                .reserved2 = {0,0,0,0,0,0,0,0},
+                                .sector_count = HPY_MEMFAULT_PART_SIZE/FLASH_SECTOR_SIZE,
+                                .start_sector = HPY_MEMFAULT_PART_START/FLASH_SECTOR_SIZE,
+                                .type = HPY_MEMFAULT_PART,
+                                .valid = 0xFF,
+                                }};
+
 //! Set-only flag to prevent PM deferred flash ops. Can't go into
 //! sQspiCoredumpPartitionInfo because of CRC and changing values of flag.
 static bool s_memfault_using_qspi;
@@ -90,21 +104,9 @@ static uint32_t prv_get_partition_info_crc(void) {
                                       offsetof(sQspiCoredumpPartitionInfo, crc));
 }
 
-static const nvms_partition_t *prv_get_core_partition(void) {
-  if (s_qspi_coredump_partition_info.magic != QSPI_COREDUMP_PART_INIT_MAGIC) {
-    return NULL;
-  }
-
-  return &s_qspi_coredump_partition_info.partition;
-}
-
-static const nvms_partition_t *prv_validate_and_get_core_partition(void) {
+static const bool prv_validate(void) {
   const uint32_t crc = prv_get_partition_info_crc();
-  if (crc != s_qspi_coredump_partition_info.crc) {
-    return NULL;
-  }
-
-  return prv_get_core_partition();
+  return crc == s_qspi_coredump_partition_info.crc;
 }
 
 // Error writing to flash - should never happen & likely detects a configuration error
@@ -120,17 +122,10 @@ static void prv_coredump_writer_assert_and_reboot(int error_code) {
 // This is Dialog specific and not extern'd in a header file.
 // NOTE: The user must call ad_nvms_init() before calling this function.
 void memfault_platform_coredump_storage_boot(void) {
-  // NOTE: The Dialog SDK automatically calls the NVMS system initialization.
-  //ad_nvms_init();
-  nvms_t part = ad_nvms_open(MEMFAULT_PLATFORM_COREDUMP_STORAGE_PARTITION);
-  if (part == NULL) {
-    MEMFAULT_LOG_ERROR("Could not locate partition for coredump storage, has ad_nvms_init() been called?");
-    return;
-  }
 
   // ad_nvms_open() should not fail if above check succeeds.
-  s_qspi_coredump_partition_info.partition.handle = part;
-  const size_t partition_size = ad_nvms_get_size(s_qspi_coredump_partition_info.partition.handle);
+  s_qspi_coredump_partition_info.partition.handle = 0;
+  const size_t partition_size = HPY_MEMFAULT_PART_SIZE;
   s_qspi_coredump_partition_info.partition.size = MEMFAULT_MIN(
       partition_size, MEMFAULT_PLATFORM_COREDUMP_STORAGE_MAX_SIZE_BYTES);
 
@@ -149,11 +144,6 @@ bool memfault_platform_saving_coredump(void) {
 // to check if it's safe to use the flash with interrupts disabled. We just need to call
 // our checker function added to ad_flash.c in the Dialog SDK.
 bool memfault_platform_coredump_save_begin(void) {
-  bool memfault_ad_flash_is_locked(void); // Defined in ad_flash.c, not in a header file
-  bool memfault_ad_nvms_direct_is_locked(void); // Defined in ad_nvms_direct.c, not in a header file
-  if (memfault_ad_flash_is_locked() || memfault_ad_nvms_direct_is_locked()) {
-    return false;
-  }
 
   // Unconditionally feed the watchdog. If it's not in use this is benign. If
   // it is in use this will give us another 2.6s to complete the coredump save.
@@ -173,8 +163,8 @@ void memfault_platform_coredump_storage_get_info(sMfltCoredumpStorageInfo *info)
 
   // we are about to perform a sequence of operations on coredump storage
   // sanity check that the memory holding the info is populated and not corrupted
-  const nvms_partition_t *core_part = prv_validate_and_get_core_partition();
-  if (core_part == NULL) {
+  const bool validated = prv_validate();
+  if (validated == false) {
     *info = (sMfltCoredumpStorageInfo) {0};
     return;
   }
@@ -189,18 +179,20 @@ bool memfault_platform_coredump_storage_read(uint32_t offset, void *data,
                                              size_t data_len) {
   MEMFAULT_ASSERT(data && data_len);
 
-  const nvms_partition_t *core_part = prv_get_core_partition();
-
-  if (core_part == NULL) {
+  if ((offset + data_len) > HPY_MEMFAULT_PART_SIZE) {
     return false;
   }
 
-  if ((offset + data_len) > core_part->size) {
-    return false;
-  }
+  // TODO -check for real partition first
+  int written = 0;
+  bool output_bool = true;
 
-  return (size_t) ad_nvms_read(core_part->handle, offset, data, data_len) == data_len;
+  written = ad_nvms_direct_driver.read(&static_mem_part, offset, data, data_len);
+  output_bool = (written == data_len);
+
+  return output_bool;
 }
+
 
 bool memfault_platform_coredump_storage_write(uint32_t offset, const void *data,
                                               size_t data_len) {
@@ -209,34 +201,49 @@ bool memfault_platform_coredump_storage_write(uint32_t offset, const void *data,
     prv_coredump_writer_assert_and_reboot(-1);
   }
 
-  const nvms_partition_t *core_part = prv_get_core_partition();
-  if (core_part == NULL) {
-    return false;
-  }
+  // It is NOT required that it be sector boundary aligned
+//  if(0 != offset % FLASH_SECTOR_SIZE)
+//  {
+//      return false;
+//  }
 
   // No support for truncation.
-  if ((offset + data_len) > core_part->size) {
+  if ((offset + data_len) > HPY_MEMFAULT_PART_SIZE) {
     return false;
   }
 
-  return (size_t) ad_nvms_write(core_part->handle, offset, data, data_len) == data_len;
+  // TODO -check for real partition first?
+  int written = 0;
+  bool output_bool = true;
+
+  written = ad_nvms_direct_driver.write(&static_mem_part, offset, data, data_len);
+  output_bool = (written == data_len);
+
+  return output_bool;
 }
 
 bool memfault_platform_coredump_storage_erase(uint32_t offset, size_t erase_size) {
-  const nvms_partition_t *core_part = prv_get_core_partition();
-  if (core_part == NULL) {
+  if(0 != offset % FLASH_SECTOR_SIZE ||
+     0 != erase_size % FLASH_SECTOR_SIZE
+          )
+  {
+      return false;
+  }
+
+  if ((offset + erase_size) > HPY_MEMFAULT_PART_SIZE) {
     return false;
   }
 
-  if ((offset + erase_size) > core_part->size) {
-    return false;
-  }
+  int written = 0;
+  bool output_bool = true;
 
-  return ad_nvms_erase_region(core_part->handle, offset, erase_size);
+  output_bool = ad_nvms_direct_driver.erase(&static_mem_part, offset, erase_size);
+
+  return output_bool;
 }
 
 void memfault_platform_coredump_storage_clear(void) {
-  memfault_platform_coredump_storage_erase(0, ad_nvms_erase_size());
+  memfault_platform_coredump_storage_erase(0, HPY_MEMFAULT_PART_SIZE);
 }
 
 #endif /* MEMFAULT_PLATFORM_COREDUMP_STORAGE_USE_FLASH */


### PR DESCRIPTION
@hh-decr Tracked down some inherent problems for the memfault coredump port.
Specifically, the Dialog ad_nvms layer relies on FreeRTOS scheduling and locks.
Please review these changes and provide comments.

- Writes are slow. Pet the wdog
- Determinism is the goal
